### PR TITLE
Fix locale options

### DIFF
--- a/Model/Translation/Source/Locales.php
+++ b/Model/Translation/Source/Locales.php
@@ -3,14 +3,13 @@ declare(strict_types=1);
 
 namespace Phpro\Translations\Model\Translation\Source;
 
+use Magento\Directory\Helper\Data;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Data\OptionSourceInterface;
 use Magento\Store\Model\StoreManager;
 
 class Locales implements OptionSourceInterface
 {
-    private const XML_PATH_LOCALE = 'general/locale/code';
-
     public function __construct(
         private readonly ScopeConfigInterface $scopeConfig,
         private readonly StoreManager $storeManager,
@@ -22,12 +21,16 @@ class Locales implements OptionSourceInterface
      */
     public function toOptionArray(): array
     {
-        $stores = $this->storeManager->getStores();
-
+        $stores = $this->storeManager->getStores(true);
+        ksort($stores);
         $result = [];
         foreach ($stores as $store) {
-            $locale = $this->scopeConfig->getValue(self::XML_PATH_LOCALE, 'stores', $store->getId());
-            $result[] = ['value' => $locale, 'label' => $store->getName()];
+            $locale = $this->scopeConfig->getValue(Data::XML_PATH_DEFAULT_LOCALE, 'stores', $store->getId());
+
+            if (isset($result[$locale])) {
+                continue;
+            }
+            $result[$locale] = ['value' => $locale, 'label' => $locale];
         }
 
         return $result;


### PR DESCRIPTION
In admin edit, the locales were shown as the Store Label instead of the locale. Also the admin locale was not available anymore.