### PR TITLE
PHP 8.5 compatible and bugfix

### DIFF
--- a/Model/Data/Translation.php
+++ b/Model/Data/Translation.php
@@ -81,7 +81,7 @@ class Translation extends AbstractExtensibleObject implements TranslationInterfa
      */
     public function getFrontend()
     {
-        return (boolean) $this->_get(self::FRONTEND);
+        return (bool) $this->_get(self::FRONTEND);
     }
 
     /**

--- a/Model/Import/Translations.php
+++ b/Model/Import/Translations.php
@@ -209,7 +209,7 @@ class Translations extends AbstractEntity
     private function insertOnDuplicate(array $entityList): int
     {
         if ($entityList) {
-            $tableName = $this->_connection->getTableName(static::TABLE);
+            $tableName = $this->_connection->getTableName(self::TABLE);
             return (int) $this->_connection->insertOnDuplicate(
                 $tableName,
                 $entityList,


### PR DESCRIPTION
Casting to (boolean) is no longer allowed in PHP8.5, this is now correctly a (bool) cast.
There was a bug when writing a plugin on the Translation class, the constant could not be retrieved because of the scope if it wasn't implemented in the plugin interceptor class.